### PR TITLE
Chain type determination fix

### DIFF
--- a/rna3db/parser.py
+++ b/rna3db/parser.py
@@ -357,8 +357,10 @@ class mmCIFParser:
         self.include_atoms = include_atoms
 
         if molecule_type == "RNA":
+            self.letters_3to1 = lambda x: modification_handler.rna_letters_3to1(x)
             self.polymer_type = "polyribonucleotide"
         elif molecule_type == "protein":
+            self.letters_3to1 = lambda x: modification_handler.protein_letters_3to1(x)
             self.polymer_type = "polypeptide"
         else:
             raise ValueError('molecule_type must be one of "RNA" or "protein".')

--- a/rna3db/parser.py
+++ b/rna3db/parser.py
@@ -496,7 +496,7 @@ class mmCIFParser:
         # Get chain/polymer types
         chain_type = {}
         for entity_id, poly_type in zip(
-            self.parsed_info["_entity_poly_seq.entity_id"],
+            self.parsed_info["_entity_poly.entity_id"],
             self.parsed_info["_entity_poly.type"],
         ):
             for author_id in id_map[entity_id]:


### PR DESCRIPTION
First of all, big thanks for your work! I am sure this dataset will greatly benefit the field of RNA structure prediction! :)

Current iteration of RNA3DB contains several DNA structures (e.g. 6O9E_E) because of the chain type determination bug in _rna3db/parser.py_. More precisely, current iteration of RNA3DB pipeline uses "_chem_comp.type"  mmCIF key to determine the type of the chain and this seemingly causes some DNA chains to be falsely classified as RNAs. I assume this is not intentional (?) so I fixed this bug by determining the chain type with the "_entity_poly.type" key instead.

It is worth noting that alongside few DNAs, there are also few DNA/RNA hybrids in the dataset (e.g. 8SVF_I). I wasn't sure if these should be removed as well so the fixes did not affect these types of chains (they aren't filtered out) but with minor code adjustments this could be changed.

I haven't tested the fixes throughly but the test script I provided below seems to be working fine:
```python
from rna3db.parser import mmCIFParser
from rna3db.parser import ModificationHandler
from pathlib import Path

parser = mmCIFParser(Path("./6O9E.cif"), ModificationHandler("cc_dict.json"))
print("6O9E RNA chains:")
print(parser.chains)

parser = mmCIFParser(Path("./8SVF.cif"), ModificationHandler("cc_dict.json"))
print("8SVF RNA chains:")
print(parser.chains)
```

New output:
```
6O9E RNA chains:
{}
8SVF RNA chains:
{'I': Chain(author_id=I, len=187), 'J': Chain(author_id=J, len=327)}
```

Old output:
```
6O9E RNA chains:
{'E': Chain(author_id=E, len=38), 'F': Chain(author_id=F, len=38)}
8SVF RNA chains:
{'I': Chain(author_id=I, len=187), 'J': Chain(author_id=J, len=327)}
```